### PR TITLE
add docker-compose.yml with timescaledb

### DIFF
--- a/battery-sensor/docker-compose.yml
+++ b/battery-sensor/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+    # backend:
+    #     depends_on:
+    #         - db
+    db:
+        image: timescale/timescaledb-ha:pg17
+        restart: always
+        ports:
+            - 5432:5432
+        volumes:
+            - itp_db:/var/lib/postgresql/data
+        environment:
+            POSTGRES_PASSWORD: postgrespassword
+volumes:
+    itp_db:


### PR DESCRIPTION
See #17 

This only adds a barebones timescaledb

It also sets a dummy password which must be changed in production, if we are to expose the database over the internet